### PR TITLE
Wrap long lines and preserve newlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 			height: auto;
 		}
 		.txt{
-			white-space: pre;
+			white-space: pre-wrap;
 			border: 1px solid #ddd;
 			border-radius: 4px;
 			padding: 14px;
@@ -178,6 +178,7 @@ You can view the source code <a href="https://github.com/Jessecar96/hangouts-rea
 					// Get message
 					for(msg_key in convo_event['chat_message']['message_content']['segment']){
 						var segment = convo_event['chat_message']['message_content']['segment'][msg_key];
+						if(segment['type'] == 'LINE_BREAK') message += "\n";
 						if(!segment['text']) continue;
 						message += twemoji.parse(segment['text']);
 					}


### PR DESCRIPTION
This is a fix for #6, and produces output that is easier to read when an archive contains chat messages with very long lines and/or line breaks.